### PR TITLE
`run_tbprofiler.py`: Use threads parameter instead of hard-coded value

### DIFF
--- a/troika_tb/utils/run_tbprofiler.py
+++ b/troika_tb/utils/run_tbprofiler.py
@@ -26,7 +26,7 @@ def get_species(kraken):
 def generate_tbprofiler_cmd(snippy, isolate, threads):
     tml = open_toml(snippy)
     bam = f"{tml[isolate]['snippy']['bam']}"
-    cmd = f"tb-profiler profile -a {bam} --caller bcftools -t 6  -d {isolate}"
+    cmd = f"tb-profiler profile -a {bam} --caller bcftools -t {threads}  -d {isolate}"
 
     return cmd
 


### PR DESCRIPTION
Fixes #10 